### PR TITLE
Fix: Safari navbar layout (JS→CSS; avoid 100vw overflow)

### DIFF
--- a/javascript/public.js
+++ b/javascript/public.js
@@ -1,5 +1,5 @@
-window.onload = function(){changeHeaderNav()}
-window.onresize = function(){changeHeaderNav()}
+window.addEventListener('DOMContentLoaded', changeHeaderNav)
+window.addEventListener('resize', changeHeaderNav)
 
 function changeHeaderNav() {
 
@@ -10,17 +10,16 @@ function changeHeaderNav() {
     var y = document.getElementById("header2")
     var z = document.getElementById("headerPara")
     var himg = document.getElementById("header_img")
-    var navcon = document.getElementById("brand")
+    // Navbar brand visibility is now handled via CSS media queries
     var mimg = document.getElementById("main_img")
 
     if (w <= 576) {
         x.style.display = "none"
         x.style.paddingRight = "0"
         y.style.display = "block"
-        y.style.paddingRight = `${w/2 - 76}px`
+        y.style.paddingRight = `${Math.max(0, w/2 - 76)}px`
         z.style.display = "none"
         z.style.paddingRight = "0"
-        navcon.style.display = "block"
         himg.style.display = "none"
         if (mimg) {
             mimg.innerHTML = "<img src='images/Introduction2.png' style='width:100%' />"
@@ -29,12 +28,11 @@ function changeHeaderNav() {
 
     else if (w < 1100) {
         x.style.display = "block"
-        x.style.paddingRight = `${w/2 - 320}px`
+        x.style.paddingRight = `${Math.max(0, w/2 - 320)}px`
         y.style.display = "none"
         y.style.paddingRight = "0"
         z.style.display = "none"
         z.style.paddingRight = "0"
-        navcon.style.display = "none"
         himg.innerHTML = "<img src='images/Westlake_Logo_1.png' style='height:3rem' />"
         himg.style.padding = "0 1rem"
         himg.style.display = "block"
@@ -45,12 +43,11 @@ function changeHeaderNav() {
 
     else if (w < 1376) {
         x.style.display = "block"
-        x.style.paddingRight = `${w/2 - 320}px`
+        x.style.paddingRight = `${Math.max(0, w/2 - 320)}px`
         y.style.display = "none"
         y.style.paddingRight = "0"
         z.style.display = "block"
-        z.style.paddingRight = `${w/2 - 314}px`
-        navcon.style.display = "none"
+        z.style.paddingRight = `${Math.max(0, w/2 - 314)}px`
         himg.innerHTML = "<img src='images/Westlake_Logo_1.png' style='height:4.38rem' />"
         himg.style.padding = "0.45rem 1.14rem"
         himg.style.display = "block"
@@ -61,12 +58,11 @@ function changeHeaderNav() {
 
     else {
         x.style.display = "block"
-        x.style.paddingRight = `${w/2 - 320}px`
+        x.style.paddingRight = `${Math.max(0, w/2 - 320)}px`
         y.style.display = "none"
         y.style.paddingRight = "0"
         z.style.display = "block"
-        z.style.paddingRight = `${w/2 - 314}px`
-        navcon.style.display = "none"
+        z.style.paddingRight = `${Math.max(0, w/2 - 314)}px`
         himg.innerHTML = "<img src='images/Westlake_Logo_0.png' style='height:4.5rem' />"
         himg.style.padding = "0.4rem 1rem"
         himg.style.display = "block"

--- a/style/public.css
+++ b/style/public.css
@@ -49,7 +49,18 @@ body {
 /* navigation bar */
 
 .navbar .container-fluid {
-    width: 60rem;
+    max-width: 60rem;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* Navbar brand visibility handled via CSS (no JS) */
+@media (max-width: 36rem) { /* <= 576px */
+    #brand { display: inline-block; }
+}
+@media (min-width: 36.0625rem) { /* > 576px */
+    #brand { display: none; }
 }
 
 .navbar-dark .navbar-nav li .nav-link {
@@ -110,7 +121,9 @@ body {
 @media only screen and (max-width: 64rem) {
     
     .navbar .container-fluid {
-        width: 100vw;
+        /* Avoid Safari's 100vw overflow issue */
+        width: 100%;
+        max-width: 100%;
     }
 
     .navbar-dark .navbar-nav li .nav-link {
@@ -127,3 +140,8 @@ body {
     }
     
 }
+
+/* Improve cross-browser sticky behavior (older Safari)
+   and ensure nav items distribute evenly in Safari */
+.sticky-top { position: -webkit-sticky; }
+.nav-fill .nav-item { flex: 1 1 0%; }


### PR DESCRIPTION
Root cause: JS toggled #brand visibility, causing Safari flex/layout glitches and horizontal overflow (100vw).

Changes:
- Remove JS control of navbar brand; handle via CSS media queries (<=576px show, >576px hide).
- Guard header paddings with Math.max(...) to prevent negatives.
- Replace 100vw with 100% for navbar container on small screens; center container with max-width on larger screens.
- Add -webkit-sticky for sticky nav support; ensure nav-fill items flex evenly in Safari.

Files updated:
- javascript/public.js
- style/public.css

Validation: Verified in Safari that navbar no longer overflows; brand shows only on small screens; toggler and sticky behavior work as expected.
